### PR TITLE
Add descriptive CMake output (and update .gitignore)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,17 @@ set(CMAKE_C_STANDARD 99)
 
 # Adding Raylib
 include(FetchContent)
+set(FETCHCONTENT_QUIET FALSE)
 set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE) # don't build the supplied examples
 set(BUILD_GAMES    OFF CACHE BOOL "" FORCE) # don't build the supplied example games
-FetchContent_Declare(raylib GIT_REPOSITORY https://github.com/raysan5/raylib.git GIT_TAG master)
+
+FetchContent_Declare(
+    raylib
+    GIT_REPOSITORY "https://github.com/raysan5/raylib.git"
+    GIT_TAG "master"
+    GIT_PROGRESS TRUE
+)
+
 FetchContent_MakeAvailable(raylib)
 
 # Adding our source files


### PR DESCRIPTION
This PR tweaks the CMake build so that instead of CMake seeming to hang on the terminal (when in actually fact it is downloading Raylib) there is terminal output indicating what CMake is doing and its progress.

Additionally the PR adds some extra files to `.gitignore` so that build files don't accidentally get committed to git.