### PR TITLE
Bump minimum cmake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(my_raylib_game C)
 set(CMAKE_C_STANDARD 99)
 


### PR DESCRIPTION
Cmake support for versions lower than 3.5 has been removed